### PR TITLE
sushi-pdf-loader: fix expected PDF filename we get back from LO

### DIFF
--- a/src/libsushi/sushi-pdf-loader.c
+++ b/src/libsushi/sushi-pdf-loader.c
@@ -230,7 +230,7 @@ load_libreoffice (SushiPdfLoader *self)
   tmp_name = g_strrstr (doc_name, ".");
   if (tmp_name)
     *tmp_name = '\0';
-  tmp_name = g_strdup_printf ("%s.pdf", tmp_name);
+  tmp_name = g_strdup_printf ("%s.pdf", doc_name);
   g_free (doc_name);
 
   pdf_dir = g_build_filename (g_get_user_cache_dir (), "sushi", NULL);


### PR DESCRIPTION
tmp_name points at the .extension we set to \0 - we want doc_name
for the base name to add .pdf to.